### PR TITLE
refactor: Combine JWT verification and user ID extraction into atomic operation

### DIFF
--- a/authn-service/src/main/java/com/peter/authnservice/service/impl/UserServiceImpl.java
+++ b/authn-service/src/main/java/com/peter/authnservice/service/impl/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.peter.authnservice.service.impl;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -128,10 +129,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void activateAccount(String token) {
-        if (!jwtUtils.validateToken(token)) {
+        UUID userId;
+        try {
+            userId = jwtUtils.verifyAndGetUserId(token);
+        } catch (JWTVerificationException e) {
             throw new TokenNotValidException("Invalid or expired verification token");
         }
-        UUID userId = jwtUtils.getUserIdFromToken(token);
 
         UserAuthentication userAuth = userAuthenticationRepository.findByUserIdAndType(userId, AuthenticationType.LOCAL)
                 .orElseThrow(() -> new UserNotFoundException("User not found"));

--- a/authn-service/src/main/java/com/peter/authnservice/util/JwtUtils.java
+++ b/authn-service/src/main/java/com/peter/authnservice/util/JwtUtils.java
@@ -120,4 +120,30 @@ public class JwtUtils {
             throw new IllegalArgumentException("Invalid user ID in token", e);
         }
     }
+
+    /**
+     * Verifies the token and extracts the user ID in a single operation.
+     *
+     * @param token the JWT token to verify
+     * @return the user ID extracted from the verified token
+     * @throws JWTVerificationException if the token is invalid, expired, malformed, or contains an invalid user ID
+     */
+    public UUID verifyAndGetUserId(String token) {
+        if (token == null || token.isEmpty()) {
+            throw new JWTVerificationException("Token cannot be null or empty");
+        }
+
+        try {
+            DecodedJWT jwt = verifier.verify(token);
+            String subject = jwt.getSubject();
+
+            if (subject == null) {
+                throw new JWTVerificationException("Token subject is null");
+            }
+
+            return UUID.fromString(subject);
+        } catch (IllegalArgumentException e) {
+            throw new JWTVerificationException("Invalid user ID in token", e);
+        }
+    }
 }

--- a/authn-service/src/test/java/com/peter/authnservice/util/JwtUtilsTest.java
+++ b/authn-service/src/test/java/com/peter/authnservice/util/JwtUtilsTest.java
@@ -2,6 +2,7 @@ package com.peter.authnservice.util;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -412,11 +413,11 @@ class JwtUtilsTest {
                 .sign(Algorithm.HMAC256(testSecret));
 
         Exception exception = assertThrows(
-                Exception.class,
+                JWTVerificationException.class,
                 () -> jwtUtils.verifyAndGetUserId(tokenWithNonNumericSubject)
         );
 
-        assertTrue(exception.getMessage().contains("Invalid user ID in token"));
+        assertEquals("Invalid user ID in token", exception.getMessage());
     }
 
     /**
@@ -427,11 +428,11 @@ class JwtUtilsTest {
         jwtUtils.init();
 
         Exception exception = assertThrows(
-                Exception.class,
+                JWTVerificationException.class,
                 () -> jwtUtils.verifyAndGetUserId(null)
         );
 
-        assertTrue(exception.getMessage().contains("Token cannot be null or empty"));
+        assertEquals("Token cannot be null or empty", exception.getMessage());
     }
 
     /**
@@ -442,11 +443,11 @@ class JwtUtilsTest {
         jwtUtils.init();
 
         Exception exception = assertThrows(
-                Exception.class,
+                JWTVerificationException.class,
                 () -> jwtUtils.verifyAndGetUserId("")
         );
 
-        assertTrue(exception.getMessage().contains("Token cannot be null or empty"));
+        assertEquals("Token cannot be null or empty", exception.getMessage());
     }
 
     /**
@@ -463,11 +464,11 @@ class JwtUtilsTest {
                 .sign(Algorithm.HMAC256(testSecret));
 
         Exception exception = assertThrows(
-                Exception.class,
+                JWTVerificationException.class,
                 () -> jwtUtils.verifyAndGetUserId(tokenWithNullSubject)
         );
 
-        assertTrue(exception.getMessage().contains("Token subject is null"));
+        assertEquals("Token subject is null", exception.getMessage());
     }
 
     /**
@@ -486,7 +487,7 @@ class JwtUtilsTest {
                 .sign(Algorithm.HMAC256(testSecret));
 
         assertThrows(
-                Exception.class,
+                JWTVerificationException.class,
                 () -> jwtUtils.verifyAndGetUserId(expiredToken)
         );
     }

--- a/authn-service/src/test/java/com/peter/authnservice/util/JwtUtilsTest.java
+++ b/authn-service/src/test/java/com/peter/authnservice/util/JwtUtilsTest.java
@@ -371,4 +371,123 @@ class JwtUtilsTest {
         assertEquals(testUserId, jwtUtils.getUserIdFromToken(token2));
         assertEquals(testUserId, jwtUtils.getUserIdFromToken(token3));
     }
+
+    /**
+     * Test verifyAndGetUserId with valid token
+     */
+    @Test
+    void verifyAndGetUserId_withValidToken_shouldReturnUserId() {
+        jwtUtils.init();
+        UUID userId = UUID.randomUUID();
+        String validToken = jwtUtils.generateVerificationToken(userId);
+
+        UUID extractedUserId = jwtUtils.verifyAndGetUserId(validToken);
+
+        assertEquals(userId, extractedUserId);
+    }
+
+    /**
+     * Test verifyAndGetUserId with invalid token
+     */
+    @Test
+    void verifyAndGetUserId_withInvalidToken_shouldThrowException() {
+        jwtUtils.init();
+        String invalidToken = "invalid.token.here";
+
+        assertThrows(Exception.class, () -> jwtUtils.verifyAndGetUserId(invalidToken));
+    }
+
+    /**
+     * Test verifyAndGetUserId with token containing non-numeric user ID
+     */
+    @Test
+    void verifyAndGetUserId_withNonNumericUserId_shouldThrowJWTVerificationException() {
+        jwtUtils.init();
+
+        // Create a token with a non-numeric subject claim
+        String tokenWithNonNumericSubject = JWT.create()
+                .withSubject("not-a-number")
+                .withIssuedAt(new Date())
+                .withExpiresAt(new Date(System.currentTimeMillis() + verificationTokenExpiration))
+                .sign(Algorithm.HMAC256(testSecret));
+
+        Exception exception = assertThrows(
+                Exception.class,
+                () -> jwtUtils.verifyAndGetUserId(tokenWithNonNumericSubject)
+        );
+
+        assertTrue(exception.getMessage().contains("Invalid user ID in token"));
+    }
+
+    /**
+     * Test verifyAndGetUserId with null token
+     */
+    @Test
+    void verifyAndGetUserId_withNullToken_shouldThrowJWTVerificationException() {
+        jwtUtils.init();
+
+        Exception exception = assertThrows(
+                Exception.class,
+                () -> jwtUtils.verifyAndGetUserId(null)
+        );
+
+        assertTrue(exception.getMessage().contains("Token cannot be null or empty"));
+    }
+
+    /**
+     * Test verifyAndGetUserId with empty token
+     */
+    @Test
+    void verifyAndGetUserId_withEmptyToken_shouldThrowJWTVerificationException() {
+        jwtUtils.init();
+
+        Exception exception = assertThrows(
+                Exception.class,
+                () -> jwtUtils.verifyAndGetUserId("")
+        );
+
+        assertTrue(exception.getMessage().contains("Token cannot be null or empty"));
+    }
+
+    /**
+     * Test verifyAndGetUserId with token containing null subject
+     */
+    @Test
+    void verifyAndGetUserId_withNullSubject_shouldThrowJWTVerificationException() {
+        jwtUtils.init();
+
+        // Create a token without a subject claim
+        String tokenWithNullSubject = JWT.create()
+                .withIssuedAt(new Date())
+                .withExpiresAt(new Date(System.currentTimeMillis() + verificationTokenExpiration))
+                .sign(Algorithm.HMAC256(testSecret));
+
+        Exception exception = assertThrows(
+                Exception.class,
+                () -> jwtUtils.verifyAndGetUserId(tokenWithNullSubject)
+        );
+
+        assertTrue(exception.getMessage().contains("Token subject is null"));
+    }
+
+    /**
+     * Test verifyAndGetUserId with expired token
+     */
+    @Test
+    void verifyAndGetUserId_withExpiredToken_shouldThrowJWTVerificationException() {
+        jwtUtils.init();
+
+        // Create an expired token
+        Date past = new Date(System.currentTimeMillis() - 10000); // 10 seconds ago
+        String expiredToken = JWT.create()
+                .withSubject(testUserId.toString())
+                .withIssuedAt(new Date(System.currentTimeMillis() - 20000))
+                .withExpiresAt(past)
+                .sign(Algorithm.HMAC256(testSecret));
+
+        assertThrows(
+                Exception.class,
+                () -> jwtUtils.verifyAndGetUserId(expiredToken)
+        );
+    }
 }


### PR DESCRIPTION
  - Add verifyAndGetUserId method to JwtUtils for atomic token verification and user ID extraction
  - Refactor activateAccount to use the new method, replacing the two-step validate-then-extract pattern
  - Add comprehensive unit tests covering edge cases: invalid tokens, null/empty tokens, malformed subjects, and expired tokens