### PR TITLE
Upgrade Spring Boot to 3.4.13 to fix CVE-2025-67735

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.11</version>
+        <version>3.4.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.peter</groupId>


### PR DESCRIPTION
This upgrade resolves CVE-2025-67735 (CVSS 6.5), a CRLF Injection vulnerability in Netty's HttpRequestEncoder. Spring Boot 3.4.13 includes Netty 4.1.130.Final, which fixes this security issue.