### PR TITLE
Fix multiple CVEs in authn-service dependencies

### DIFF
--- a/authn-service/pom.xml
+++ b/authn-service/pom.xml
@@ -28,6 +28,8 @@
     </scm>
     <properties>
         <java.version>21</java.version>
+        <!-- Override kafka-clients to fix CVE-2025-27817 and CVE-2025-27818 -->
+        <kafka.version>3.9.1</kafka.version>
     </properties>
     <profiles>
         <profile>
@@ -105,11 +107,25 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
+            <exclusions>
+                <!-- Exclude vulnerable org.lz4:lz4-java, replaced with at.yawk.lz4:lz4-java -->
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude vulnerable org.lz4:lz4-java, replaced with at.yawk.lz4:lz4-java -->
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -138,6 +154,31 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.18.0</version>
+        </dependency>
+        <!-- Override lz4-java to fix CVE-2025-66566 -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.10.1</version>
+        </dependency>
+        <!-- Override commons-beanutils to fix CVE-2025-48734 -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Override jose4j to fix CVE-2024-29371 -->
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.9.6</version>
+        </dependency>
+        <!-- Override netty-codec-http to fix CVE-2025-67735 -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.1.130.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
  - Upgrade kafka-clients to 3.9.1 to fix CVE-2025-27817 and CVE-2025-27818
  - Replace org.lz4:lz4-java with at.yawk.lz4:lz4-java 1.10.1 to fix CVE-2025-66566
  - Upgrade commons-beanutils to 1.11.0 to fix CVE-2025-48734
  - Upgrade jose4j to 0.9.6 to fix CVE-2024-29371
  - Upgrade netty-codec-http to 4.1.130.Final to fix CVE-2025-67735